### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 このプロジェクトは、Waroom APIとインタラクションするためのModel Context Protocol (MCP) サーバーです。標準化されたプロトコルを使用して、Waroomから様々な情報を取得することができます。
 
+<a href="https://glama.ai/mcp/servers/@topotal/waroom-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@topotal/waroom-mcp/badge" alt="Waroom MCP server" />
+</a>
+
 ## 概要
 
 Waroom MCP サーバーは、Waroom APIエンドポイントに構造化された方法でアクセスする方法を提供します。インシデント情報やポストモーテム情報の取得など、さまざまな機能をサポートしています。


### PR DESCRIPTION
This PR adds a badge for the [Waroom MCP](https://glama.ai/mcp/servers/@topotal/waroom-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@topotal/waroom-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@topotal/waroom-mcp/badge" alt="Waroom MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.