### PR TITLE
feat: add labels management tools for MCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ node dist/main.js
   - `incidents.ts`: インシデント関連のツール（作成、一覧取得、詳細取得、重要度・ステータス更新、メトリクス作成）
   - `postmortems.ts`: ポストモーテム関連のツール（一覧取得、作成、テンプレート取得）
   - `services.ts`: サービス関連のツール（一覧取得、アーキテクチャコンテキスト取得）
+  - `labels.ts`: ラベル管理のツール（サービスラベル一覧取得、作成、更新、削除、インシデントラベル付与）
 
 ### 技術スタック
 
@@ -72,6 +73,11 @@ node dist/main.js
 - `waroom_update_incident_severity`: インシデント重要度の更新
 - `waroom_update_incident_status`: インシデントステータスの更新
 - `waroom_create_incident_metrics`: インシデントメトリクスの作成（TTD/TTA/TTI/TTF/TTR更新）
+- `waroom_get_service_labels`: 特定のサービスのラベル一覧を取得
+- `waroom_create_service_label`: 特定のサービスに新しいラベルを作成
+- `waroom_update_service_label`: 特定のサービスのラベルを更新
+- `waroom_delete_service_label`: 特定のサービスのラベルを削除
+- `waroom_update_incident_labels`: インシデントにラベルを付与または更新
 
 ### API エンドポイント
 
@@ -88,6 +94,11 @@ node dist/main.js
 - `PUT /internal/incidents/{uuid}/severity`: インシデント重要度の更新
 - `PUT /internal/incidents/{uuid}/status`: インシデントステータスの更新
 - `POST /internal/incidents/{uuid}/metrics`: インシデントメトリクスの作成
+- `GET /internal/services/{service_name}/labels`: サービスのラベル一覧取得
+- `POST /internal/services/{service_name}/labels`: サービスのラベル作成
+- `PATCH /internal/services/{service_name}/labels/{uuid}`: サービスのラベル更新
+- `DELETE /internal/services/{service_name}/labels/{uuid}`: サービスのラベル削除
+- `PATCH /internal/incidents/{uuid}/labels`: インシデントのラベル付与/更新
 
 ## Claude Desktop での設定
 

--- a/src/WaroomClient.ts
+++ b/src/WaroomClient.ts
@@ -157,4 +157,63 @@ export class WaroomClient {
       throw new Error(`Failed to create incident metrics: ${error}`);
     }
   }
+
+  async getServiceLabels(serviceName: string, page = 1, perPage = 50) {
+    try {
+      const response = await this.axiosInstance.get(`${this.baseUrl}/internal/services/${serviceName}/labels`, {
+        params: { page, per_page: perPage }
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to get service labels: ${error}`);
+    }
+  }
+
+  async createServiceLabel(serviceName: string, name: string, color: string) {
+    try {
+      const response = await this.axiosInstance.post(`${this.baseUrl}/internal/services/${serviceName}/labels`, {
+        label: {
+          name,
+          color
+        }
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to create service label: ${error}`);
+    }
+  }
+
+  async updateServiceLabel(serviceName: string, labelUuid: string, name: string, color: string) {
+    try {
+      const response = await this.axiosInstance.patch(`${this.baseUrl}/internal/services/${serviceName}/labels/${labelUuid}`, {
+        label: {
+          name,
+          color
+        }
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to update service label: ${error}`);
+    }
+  }
+
+  async deleteServiceLabel(serviceName: string, labelUuid: string) {
+    try {
+      const response = await this.axiosInstance.delete(`${this.baseUrl}/internal/services/${serviceName}/labels/${labelUuid}`);
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to delete service label: ${error}`);
+    }
+  }
+
+  async updateIncidentLabels(incidentUuid: string, labelUuids: string[]) {
+    try {
+      const response = await this.axiosInstance.patch(`${this.baseUrl}/internal/incidents/${incidentUuid}/labels`, {
+        label_uuids: labelUuids
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to update incident labels: ${error}`);
+    }
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { WaroomClient } from './WaroomClient.js';
 import { createIncidentsTools } from './tools/incidents.js';
 import { createPostmortemsTools } from './tools/postmortems.js';
 import { createServicesTools } from './tools/services.js';
+import { createLabelsTools } from './tools/labels.js';
 
 dotenv.config();
 
@@ -21,6 +22,7 @@ const server = new McpServer({
 createIncidentsTools(server, waroomClient);
 createPostmortemsTools(server, waroomClient);
 createServicesTools(server, waroomClient);
+createLabelsTools(server, waroomClient);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -1,0 +1,163 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WaroomClient } from '../WaroomClient.js';
+import { z } from 'zod';
+
+export const createLabelsTools = (server: McpServer, waroomClient: WaroomClient) => {
+  server.tool(
+    'waroom_get_service_labels',
+    '特定のサービスのラベル一覧を取得します。',
+    {
+      service_name: z.string().min(1).max(100).describe('サービス名'),
+      page: z.number().int().min(1).optional().describe('取得するページ番号（1以上の整数）。デフォルト: 1'),
+      per_page: z.number().int().min(1).max(100).optional().describe('1ページあたりの取得数（1-100）。デフォルト: 50'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.getServiceLabels(
+          params.service_name,
+          params.page || 1,
+          params.per_page || 50
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `サービスラベル一覧の取得に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'waroom_create_service_label',
+    '特定のサービスに新しいラベルを作成します。',
+    {
+      service_name: z.string().min(1).max(100).describe('サービス名'),
+      name: z.string().min(1).max(100).describe('ラベル名'),
+      color: z.string().regex(/^[0-9a-fA-F]{6}$/).describe('ラベルの色（6桁の16進数カラーコード、例: ff0000）'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.createServiceLabel(
+          params.service_name,
+          params.name,
+          params.color
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `サービスラベルの作成に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'waroom_update_service_label',
+    '特定のサービスのラベルを更新します。',
+    {
+      service_name: z.string().min(1).max(100).describe('サービス名'),
+      label_uuid: z.string().uuid().describe('更新するラベルのUUID'),
+      name: z.string().min(1).max(100).describe('新しいラベル名'),
+      color: z.string().regex(/^[0-9a-fA-F]{6}$/).describe('新しいラベルの色（6桁の16進数カラーコード、例: ff0000）'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.updateServiceLabel(
+          params.service_name,
+          params.label_uuid,
+          params.name,
+          params.color
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `サービスラベルの更新に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'waroom_delete_service_label',
+    '特定のサービスのラベルを削除します。',
+    {
+      service_name: z.string().min(1).max(100).describe('サービス名'),
+      label_uuid: z.string().uuid().describe('削除するラベルのUUID'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.deleteServiceLabel(
+          params.service_name,
+          params.label_uuid
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `サービスラベルの削除に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'waroom_update_incident_labels',
+    'インシデントにラベルを付与または更新します。',
+    {
+      incident_uuid: z.string().uuid().describe('対象インシデントのUUID'),
+      label_uuids: z.array(z.string().uuid()).describe('付与するラベルのUUID配列'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.updateIncidentLabels(
+          params.incident_uuid,
+          params.label_uuids
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `インシデントラベルの更新に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+};


### PR DESCRIPTION
## Summary

Waroom backend PR #2180でラベル管理APIが追加されたため、waroom-mcpに対応するツールを実装しました。

### 🚀 追加された機能

#### 新しいMCPツール (5個)
- **waroom_get_service_labels**: サービスのラベル一覧を取得
- **waroom_create_service_label**: サービスに新しいラベルを作成
- **waroom_update_service_label**: サービスのラベルを更新
- **waroom_delete_service_label**: サービスのラベルを削除
- **waroom_update_incident_labels**: インシデントにラベルを付与/更新

#### 技術的な変更
- **WaroomClient.ts**: ラベル管理用のHTTPメソッド追加
- **src/tools/labels.ts**: ラベル管理ツールの実装
- **main.ts**: ラベルツールの登録
- **CLAUDE.md**: ドキュメント更新

### 📋 対応したAPIエンドポイント

#### サービスラベル管理
- `GET /internal/services/{service_name}/labels` - ラベル一覧取得
- `POST /internal/services/{service_name}/labels` - ラベル作成
- `PATCH /internal/services/{service_name}/labels/{uuid}` - ラベル更新
- `DELETE /internal/services/{service_name}/labels/{uuid}` - ラベル削除

#### インシデントラベル管理
- `PATCH /internal/incidents/{uuid}/labels` - インシデントのラベル付与/更新

### 🔧 仕様詳細

#### カラー値のバリデーション
- 6桁の16進数でバリデーション（例: `ff0000`, `00ff00`, `0000ff`）
- シャープ（#）は含まない形式

#### API 設計
- 全ツールで日本語の説明とzodバリデーションを完備
- エラーハンドリングとレスポンス形式を既存ツールと統一
- ページネーション対応（ラベル一覧取得）

### 🧪 テスト

- [x] TypeScriptビルド成功
- [x] 全ツールの型安全性確認
- [x] zodバリデーション動作確認

## Test plan

- [x] TypeScriptコンパイル成功
- [x] 新しいツールの型定義確認
- [x] CLAUDE.mdドキュメント更新完了
- [ ] 実際のAPI動作確認（Waroom backend PR #2180マージ後）

🤖 Generated with [Claude Code](https://claude.ai/code)