### PR TITLE
feat: migrate from internal API to v0 API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,18 +23,18 @@ npm run lint
 # MCP Inspector でデバッグ
 npm run inspector
 
-# サーバー実行（Internal API を使用）
+# サーバー実行（v0 API を使用）
 node dist/main.js
 ```
 
 ## アーキテクチャ
 
-このプロジェクトは Waroom Internal API に接続する Model Context Protocol (MCP) サーバーです。
+このプロジェクトは Waroom v0 API に接続する Model Context Protocol (MCP) サーバーです。
 
 ### 主要コンポーネント
 
 - `src/main.ts`: MCPサーバーのエントリーポイント。StdioTransportを使用してMCPサーバーを起動
-- `src/WaroomClient.ts`: Waroom Internal API と通信するHTTPクライアント。axios ベース、認証ヘッダー管理
+- `src/WaroomClient.ts`: Waroom v0 API と通信するHTTPクライアント。axios ベース、認証ヘッダー管理
 - `src/tools/`: MCP ツール定義
   - `incidents.ts`: インシデント関連のツール（作成、一覧取得、詳細取得、重要度・ステータス更新、メトリクス作成）
   - `postmortems.ts`: ポストモーテム関連のツール（一覧取得、作成、テンプレート取得）
@@ -83,22 +83,22 @@ node dist/main.js
 
 ベースURL: `https://api.app.waroom.com/api/v0`
 
-- `POST /internal/incidents`: インシデント作成
-- `GET /internal/incidents`: インシデント一覧（statusパラメータでフィルタリング可能）
-- `GET /internal/incidents/{uuid}`: インシデント詳細
-- `GET /internal/postmortems`: ポストモーテム一覧
-- `POST /internal/postmortems`: ポストモーテム作成
-- `GET /internal/postmortem_template`: ポストモーテムテンプレート取得
-- `GET /internal/services`: サービス一覧
-- `GET /internal/services/{name}/service_architecture_context`: 特定のサービスのアーキテクチャコンテキスト取得
-- `PUT /internal/incidents/{uuid}/severity`: インシデント重要度の更新
-- `PUT /internal/incidents/{uuid}/status`: インシデントステータスの更新
-- `POST /internal/incidents/{uuid}/metrics`: インシデントメトリクスの作成
-- `GET /internal/services/{service_name}/labels`: サービスのラベル一覧取得
-- `POST /internal/services/{service_name}/labels`: サービスのラベル作成
-- `PATCH /internal/services/{service_name}/labels/{uuid}`: サービスのラベル更新
-- `DELETE /internal/services/{service_name}/labels/{uuid}`: サービスのラベル削除
-- `PATCH /internal/incidents/{uuid}/labels`: インシデントのラベル付与/更新
+- `POST /incidents`: インシデント作成
+- `GET /incidents`: インシデント一覧（statusパラメータでフィルタリング可能）
+- `GET /incidents/{uuid}`: インシデント詳細
+- `GET /postmortems`: ポストモーテム一覧
+- `POST /postmortems`: ポストモーテム作成
+- `GET /postmortem_template`: ポストモーテムテンプレート取得
+- `GET /services`: サービス一覧
+- `GET /services/{name}/service_architecture_context`: 特定のサービスのアーキテクチャコンテキスト取得
+- `PUT /incidents/{uuid}/severity`: インシデント重要度の更新
+- `PUT /incidents/{uuid}/status`: インシデントステータスの更新
+- `POST /incidents/{uuid}/metrics`: インシデントメトリクスの作成
+- `GET /services/{service_name}/labels`: サービスのラベル一覧取得
+- `POST /services/{service_name}/labels`: サービスのラベル作成
+- `PATCH /services/{service_name}/labels/{uuid}`: サービスのラベル更新
+- `DELETE /services/{service_name}/labels/{uuid}`: サービスのラベル削除
+- `PATCH /incidents/{uuid}/labels`: インシデントのラベル付与/更新
 
 ## Claude Desktop での設定
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topotal/waroom-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Waroom MCP Server - Access Waroom API through Model Context Protocol",
   "publishConfig": {
     "access": "public"

--- a/src/WaroomClient.ts
+++ b/src/WaroomClient.ts
@@ -35,7 +35,7 @@ export class WaroomClient {
       if (filters.label_names?.length) params.label_names = filters.label_names.join(',');
       if (filters.commander_id) params.commander_id = filters.commander_id;
 
-      const response = await this.axiosInstance.get(`${this.baseUrl}/internal/incidents`, { params });
+      const response = await this.axiosInstance.get(`${this.baseUrl}/incidents`, { params });
       return response.data;
     } catch (error) {
       throw new Error(`Failed to get incidents: ${error}`);
@@ -44,7 +44,7 @@ export class WaroomClient {
 
   async getIncidentDetails(incidentUuid: string) {
     try {
-      const response = await this.axiosInstance.get(`${this.baseUrl}/internal/incidents/${incidentUuid}`);
+      const response = await this.axiosInstance.get(`${this.baseUrl}/incidents/${incidentUuid}`);
       return response.data;
     } catch (error) {
       throw new Error(`Failed to get incident details: ${error}`);
@@ -53,7 +53,7 @@ export class WaroomClient {
 
   async getPostmortems(page = 1, perPage = 50) {
     try {
-      const response = await this.axiosInstance.get(`${this.baseUrl}/internal/postmortems`, {
+      const response = await this.axiosInstance.get(`${this.baseUrl}/postmortems`, {
         params: { page, per_page: perPage }
       });
       return response.data;
@@ -64,7 +64,7 @@ export class WaroomClient {
 
   async createPostmortem(title: string, blob: string, incidentUuids: string[], status?: string) {
     try {
-      const response = await this.axiosInstance.post(`${this.baseUrl}/internal/postmortems`, {
+      const response = await this.axiosInstance.post(`${this.baseUrl}/postmortems`, {
         title,
         blob,
         incident_uuids: incidentUuids,
@@ -79,7 +79,7 @@ export class WaroomClient {
 
   async getServices(page = 1, perPage = 50) {
     try {
-      const response = await this.axiosInstance.get(`${this.baseUrl}/internal/services`, {
+      const response = await this.axiosInstance.get(`${this.baseUrl}/services`, {
         params: { page, per_page: perPage }
       });
       return response.data;
@@ -90,7 +90,7 @@ export class WaroomClient {
 
   async getPostmortemTemplate() {
     try {
-      const response = await this.axiosInstance.get(`${this.baseUrl}/internal/postmortem_template`);
+      const response = await this.axiosInstance.get(`${this.baseUrl}/postmortem_template`);
       return response.data;
     } catch (error) {
       throw new Error(`Failed to get postmortem template: ${error}`);
@@ -99,7 +99,7 @@ export class WaroomClient {
 
   async getServiceArchitectureContext(serviceName: string) {
     try {
-      const response = await this.axiosInstance.get(`${this.baseUrl}/internal/services/${serviceName}/service_architecture_context`);
+      const response = await this.axiosInstance.get(`${this.baseUrl}/services/${serviceName}/service_architecture_context`);
       return response.data;
     } catch (error) {
       throw new Error(`Failed to get service architecture context: ${error}`);
@@ -108,7 +108,7 @@ export class WaroomClient {
 
   async createIncident(serviceNameorId: string, title: string, severity: string, description?: string, experimental?: boolean, isPrivate?: boolean) {
     try {
-      const response = await this.axiosInstance.post(`${this.baseUrl}/internal/incidents`, {
+      const response = await this.axiosInstance.post(`${this.baseUrl}/incidents`, {
         incident: {
           service_name: serviceNameorId,
           title,
@@ -126,7 +126,7 @@ export class WaroomClient {
 
   async updateIncidentSeverity(incidentUuid: string, severity: string) {
     try {
-      const response = await this.axiosInstance.put(`${this.baseUrl}/internal/incidents/${incidentUuid}/severity`, {
+      const response = await this.axiosInstance.put(`${this.baseUrl}/incidents/${incidentUuid}/severity`, {
         severity
       });
       return response.data;
@@ -137,7 +137,7 @@ export class WaroomClient {
 
   async updateIncidentStatus(incidentUuid: string, status: string) {
     try {
-      const response = await this.axiosInstance.put(`${this.baseUrl}/internal/incidents/${incidentUuid}/status`, {
+      const response = await this.axiosInstance.put(`${this.baseUrl}/incidents/${incidentUuid}/status`, {
         status
       });
       return response.data;
@@ -148,7 +148,7 @@ export class WaroomClient {
 
   async createIncidentMetrics(incidentUuid: string, activityAction: string, triggeredAt: string) {
     try {
-      const response = await this.axiosInstance.post(`${this.baseUrl}/internal/incidents/${incidentUuid}/metrics`, {
+      const response = await this.axiosInstance.post(`${this.baseUrl}/incidents/${incidentUuid}/metrics`, {
         activity_action: activityAction,
         triggered_at: triggeredAt
       });
@@ -160,7 +160,7 @@ export class WaroomClient {
 
   async getServiceLabels(serviceName: string, page = 1, perPage = 50) {
     try {
-      const response = await this.axiosInstance.get(`${this.baseUrl}/internal/services/${serviceName}/labels`, {
+      const response = await this.axiosInstance.get(`${this.baseUrl}/services/${serviceName}/labels`, {
         params: { page, per_page: perPage }
       });
       return response.data;
@@ -171,7 +171,7 @@ export class WaroomClient {
 
   async createServiceLabel(serviceName: string, name: string, color: string) {
     try {
-      const response = await this.axiosInstance.post(`${this.baseUrl}/internal/services/${serviceName}/labels`, {
+      const response = await this.axiosInstance.post(`${this.baseUrl}/services/${serviceName}/labels`, {
         label: {
           name,
           color
@@ -185,7 +185,7 @@ export class WaroomClient {
 
   async updateServiceLabel(serviceName: string, labelUuid: string, name: string, color: string) {
     try {
-      const response = await this.axiosInstance.patch(`${this.baseUrl}/internal/services/${serviceName}/labels/${labelUuid}`, {
+      const response = await this.axiosInstance.patch(`${this.baseUrl}/services/${serviceName}/labels/${labelUuid}`, {
         label: {
           name,
           color
@@ -199,7 +199,7 @@ export class WaroomClient {
 
   async deleteServiceLabel(serviceName: string, labelUuid: string) {
     try {
-      const response = await this.axiosInstance.delete(`${this.baseUrl}/internal/services/${serviceName}/labels/${labelUuid}`);
+      const response = await this.axiosInstance.delete(`${this.baseUrl}/services/${serviceName}/labels/${labelUuid}`);
       return response.data;
     } catch (error) {
       throw new Error(`Failed to delete service label: ${error}`);
@@ -208,7 +208,7 @@ export class WaroomClient {
 
   async updateIncidentLabels(incidentUuid: string, labelUuids: string[]) {
     try {
-      const response = await this.axiosInstance.patch(`${this.baseUrl}/internal/incidents/${incidentUuid}/labels`, {
+      const response = await this.axiosInstance.patch(`${this.baseUrl}/incidents/${incidentUuid}/labels`, {
         label_uuids: labelUuids
       });
       return response.data;


### PR DESCRIPTION
## 背景
backend側のPR #2260と#2264でinternal APIがv0 APIに昇格されたため、waroom-mcpも対応する必要がある。

## やったこと
- すべてのAPIエンドポイントから `/internal/` プレフィックスを削除
- 16個のエンドポイントを更新：
  - `POST /internal/incidents` → `POST /incidents`
  - `GET /internal/incidents` → `GET /incidents`
  - `GET /internal/postmortems` → `GET /postmortems`
  - `GET /internal/services` → `GET /services`
  - その他、labels、metrics、status関連のエンドポイント
- CLAUDE.mdのドキュメントをv0 API仕様に更新
- package.jsonのバージョンを0.5.0に更新

## 確認事項
- [x] TypeScriptコンパイル成功
- [x] 既存機能に破壊的変更なし（エンドポイントURLのみ変更）
- [x] backend側PRと同期したAPI仕様

🤖 Generated with [Claude Code](https://claude.ai/code)