### PR TITLE
feat: Add MCP slash command for incident response

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,11 @@
 {
   "mcpServers": {
     "notion": {
+      "type": "http",
       "url": "https://mcp.notion.com/mcp"
     },
     "sentry": {
+      "type": "http",
       "url": "https://mcp.sentry.dev/mcp"
     }
   }

--- a/README.md
+++ b/README.md
@@ -73,3 +73,36 @@ claude mcp add waroom-mcp --env WAROOM_API_KEY=your-api-key -- npx @topotal/waro
 - `waroom_create_service_label`: 特定のサービスに新しいラベルを作成
 - `waroom_update_service_label`: 特定のサービスのラベルを更新
 - `waroom_delete_service_label`: 特定のサービスのラベルを削除
+
+## スラッシュコマンド（Claude Code）
+
+Claude Code では、以下のスラッシュコマンドを使用してインシデント対応を効率化できます。
+
+### `/mcp__waroom_mcp__create`
+
+インシデント対応を開始し、作業内容を自動追跡するスラッシュコマンドです。
+
+#### 使い方
+
+```bash
+# タイトル指定あり
+/mcp__waroom_mcp__create "データベース接続エラー"
+
+# タイトル指定なし（対話で質問）
+/mcp__waroom_mcp__create
+```
+
+#### 主な機能
+
+- **サービスの自動検索**: サービス一覧から対話的に選択
+- **インシデントの自動作成**: 重要度 `unknown` で自動作成
+- **作業の自動追跡**: レスポンダーの発言から自動的にフェーズを判断し、Waroomを更新
+  - 調査開始 → `investigating` + TTD記録
+  - 原因特定 → TTA記録
+  - 修正開始 → `fixing` + TTI記録
+  - 修正完了 → `resolved` + TTF/TTR記録
+- **継続的な更新**: 会話全体でインシデント情報を最新状態に保持
+
+#### 使用シーン
+
+レスポンダーがClaude Codeでインシデント対応作業（コード調査、ログ確認、修正作業）を進める際に、自動的にWaroomのインシデント情報を更新し、記録を残すことができます。明示的に指示しなくても、作業内容から自動判断して適切なステータスやメトリクスを更新します。

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import dotenv from 'dotenv';
+import { z } from 'zod';
 import { WaroomClient } from './WaroomClient.js';
 import { createIncidentsTools } from './tools/incidents.js';
 import { createPostmortemsTools } from './tools/postmortems.js';
 import { createServicesTools } from './tools/services.js';
 import { createLabelsTools } from './tools/labels.js';
+import { getIncidentResponsePromptMessages } from './prompts/incident-response.js';
 
 dotenv.config();
 
@@ -23,6 +25,20 @@ createIncidentsTools(server, waroomClient);
 createPostmortemsTools(server, waroomClient);
 createServicesTools(server, waroomClient);
 createLabelsTools(server, waroomClient);
+
+// プロンプトの登録
+server.prompt(
+  'create',
+  'Waroomでインシデント対応を開始します。サービスを検索してインシデントを作成し、作業を自動追跡します。',
+  {
+    title: z.string().min(1).optional().describe('インシデントのタイトル（省略可、省略時は対話で質問）'),
+  },
+  async (args) => {
+    return {
+      messages: getIncidentResponsePromptMessages(args.title),
+    };
+  }
+);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/src/prompts/incident-response.ts
+++ b/src/prompts/incident-response.ts
@@ -1,0 +1,111 @@
+export const getIncidentResponsePromptMessages = (
+  title?: string
+) => {
+  // titleが指定されていない場合
+  if (!title) {
+    return [
+      {
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: `# Waroomインシデント対応開始
+
+まず、ユーザーに「どのようなインシデントが発生しましたか？（インシデントのタイトルを教えてください）」と質問してください。
+
+タイトルを受け取ったら、以下の手順でインシデント対応を開始してください。`,
+        },
+      },
+    ];
+  }
+
+  // titleが指定されている場合
+  return [
+    {
+      role: 'user' as const,
+      content: {
+        type: 'text' as const,
+        text: `# Waroomインシデント対応開始
+
+以下のインシデントが発生しました:
+
+**インシデントタイトル**: ${title}
+
+## あなたの役割
+
+**重要**: あなたはレスポンダー（インシデント対応者）の作業を継続的に追跡し、Waroomのインシデント情報を自動的に更新するアシスタントです。
+
+この会話全体を通じて、以下を実行してください：
+
+## 初期セットアップ
+
+### 1. サービスの特定とインシデント作成
+1. \`waroom_get_services\` でサービス一覧を取得
+2. ユーザーに「どのサービスで発生したインシデントですか？」と質問
+3. ユーザーの回答から部分一致でサービスを特定（候補が複数ある場合は確認）
+4. \`waroom_create_incident\` で即座にインシデントを作成:
+   - service_name: （特定したサービス名）
+   - title: ${title}
+   - severity: unknown
+5. **作成したインシデントのUUIDとサービス名を記憶し、この会話全体で使用する**
+6. \`waroom_get_service_architecture_context\` でサービスのアーキテクチャ情報を取得・提示
+
+### 2. 初期ステータス更新
+インシデント作成後、自動的に以下を実行：
+- \`waroom_update_incident_status\` で \`investigating\` に更新
+- \`waroom_create_incident_metrics\` で調査開始時刻を記録（activity_action: "investigating"）
+
+## 継続的な自動追跡（最重要）
+
+**レスポンダーの発言や作業内容から自動的にフェーズを判断し、Waroomを更新してください。レスポンダーが明示的に指示しなくても実行します。**
+
+### フェーズ判断と自動更新のルール
+
+#### 🔍 調査フェーズ（Investigating）
+**トリガー**: 「ログを確認」「調査します」「原因を探ります」など
+**自動実行**:
+- ステータスが \`investigating\` でなければ更新
+- TTD（Time To Detect）メトリクスを記録
+
+#### 💡 原因特定時
+**トリガー**: 「原因は〜です」「特定しました」「〜が問題です」など
+**自動実行**:
+- TTA（Time To Acknowledge）メトリクスを記録
+- 必要に応じて重要度を更新
+
+#### 🔧 修正フェーズ（Fixing）
+**トリガー**: 「修正します」「デプロイします」「対応開始」など
+**自動実行**:
+- \`waroom_update_incident_status\` で \`fixing\` に更新
+- TTI（Time To Investigate）メトリクスを記録（activity_action: "fixing"）
+
+#### ✅ 解決フェーズ（Resolved）
+**トリガー**: 「修正完了」「デプロイ完了」「解決しました」など
+**自動実行**:
+- \`waroom_update_incident_status\` で \`resolved\` に更新
+- TTF（Time To Fix）とTTR（Time To Resolve）メトリクスを記録（activity_action: "resolved"）
+
+#### 🔒 クローズフェーズ（Close）
+**トリガー**: 「クローズします」「問題なし」「最終確認完了」など
+**自動実行**:
+- \`waroom_update_incident_status\` で \`close\` に更新
+
+### 重要度の自動更新
+レスポンダーの発言から影響度が判明した場合、\`waroom_update_incident_severity\` で自動更新:
+- 「サービス停止」「全ユーザー影響」→ critical
+- 「一部機能停止」「複数ユーザー影響」→ high
+- 「軽微な問題」「影響小」→ low
+
+## 会話スタイル
+
+- レスポンダーの通常の作業（コード調査、ログ確認、修正作業）をサポート
+- フェーズ移行を検知したら、**黙って自動的にWaroomを更新**（更新したことは簡潔に報告）
+- 「〜を検討してください」ではなく、必要なアクションは自動実行
+- インシデント情報は常に最新の状態を保つ
+
+---
+
+それでは、上記のルールに従って、レスポンダーのインシデント対応をサポートしてください。`,
+      },
+    },
+  ];
+};


### PR DESCRIPTION
## 概要

インシデント対応を開始するMCPスラッシュコマンド `/mcp__waroom_mcp__create` を追加しました。

## 主な機能

### スラッシュコマンド
```
# タイトル指定あり
/mcp__waroom_mcp__create "DB接続エラー"

# タイトル指定なし（プロンプト内で質問）
/mcp__waroom_mcp__create
```

### 自動追跡機能
レスポンダーの発言や作業内容から自動的にフェーズを判断し、Waroomのインシデント情報を更新します。

- **調査開始**: `investigating` + TTD記録
- **原因特定**: TTA記録
- **修正開始**: `fixing` + TTI記録
- **修正完了**: `resolved` + TTF/TTR記録

### その他の機能
- サービス名の対話的な検索・選択
- インシデントの自動作成（重要度: unknown）
- サービスアーキテクチャコンテキストの自動取得
- 会話全体でインシデント情報を最新状態に保持

## 実装内容

- `src/prompts/incident-response.ts`: プロンプト定義とメッセージ生成ロジック
- `src/main.ts`: MCPプロンプトの登録

## 使用シーン

レスポンダーがClaude Codeでインシデント対応作業（コード調査、ログ確認、修正作業）を進める際に、自動的にWaroomのインシデント情報を更新し、記録を残すことができます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)