### PR TITLE
fix: Correct order of name and uri parameters in server.resource()

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,8 +29,8 @@ createLabelsTools(server, waroomClient);
 
 // リソースの登録
 server.resource(
-  'waroom://about',
   'Waroom MCP の使い方ガイド - インシデント対応の自動化とポストモーテム管理',
+  'waroom://about',
   async () => {
     return {
       contents: [


### PR DESCRIPTION
## 概要

Issue #11 で報告された、`server.resource()` の `name` と `uri` パラメータの順序が逆になっていた問題を修正しました。

## 変更内容

### 修正前
```typescript
server.resource(
  'waroom://about',  // uri
  'Waroom MCP の使い方ガイド - インシデント対応の自動化とポストモーテム管理',  // name
  async () => { ... }
);
```

### 修正後
```typescript
server.resource(
  'Waroom MCP の使い方ガイド - インシデント対応の自動化とポストモーテム管理',  // name
  'waroom://about',  // uri
  async () => { ... }
);
```

## 影響

- ✅ `ReadMcpResourceTool(uri: "waroom://about")` で正しくリソースを取得できるようになります
- ✅ MCP 仕様に準拠したリソース登録になります
- ✅ `@` 記法での参照も引き続き動作します

## 関連Issue

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)