### PR TITLE
fix: Make incident description required parameter

### DIFF
--- a/src/tools/incidents.ts
+++ b/src/tools/incidents.ts
@@ -10,7 +10,7 @@ export const createIncidentsTools = (server: McpServer, waroomClient: WaroomClie
       service_name: z.string().min(1).describe('サービス名またはサービスID'),
       title: z.string().min(1).max(255).describe('インシデントのタイトル（1-255文字）'),
       severity: z.enum(['critical', 'high', 'low', 'info', 'unknown']).describe('重要度（critical, high, low, info, unknown）'),
-      description: z.string().optional().describe('インシデントの説明（オプション）'),
+      description: z.string().min(1).describe('インシデントの説明'),
       experimental: z.boolean().default(false).describe('実験的なインシデントかどうか（デフォルト: false）'),
       is_private: z.boolean().default(false).describe('プライベートインシデントかどうか（デフォルト: false）'),
     },


### PR DESCRIPTION
## 概要

`waroom_create_incident` ツールの `description` パラメータを必須に変更しました。

## 変更内容

- `description` パラメータを `optional` から `required` に変更
- バリデーション: `z.string().optional()` → `z.string().min(1)`

## 背景

インシデント作成時に説明は重要な情報であり、必須とすることで
より詳細な情報を記録できるようにします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)