### PR TITLE
fix: Pin axios to 1.9.0 to prevent supply chain attack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@topotal/waroom-mcp",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@topotal/waroom-mcp",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",
         "@types/node": "^22.15.18",
-        "axios": "^1.9.0",
+        "axios": "1.9.0",
         "dotenv": "^16.5.0",
         "typescript": "^5.8.3",
         "zod": "^3.24.4"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.19.1",
     "@types/node": "^22.15.18",
-    "axios": "^1.9.0",
+    "axios": "1.9.0",
     "dotenv": "^16.5.0",
     "typescript": "^5.8.3",
     "zod": "^3.24.4"


### PR DESCRIPTION
## Summary
- axios@1.14.1がサプライチェーン攻撃により侵害されたため、バージョンを`1.9.0`に固定
- `^1.9.0` → `1.9.0` に変更し、意図しないアップグレードを防止
- 悪意のある依存関係 `plain-crypto-js@4.2.1` がRAT（リモートアクセストロイの木馬）をドロップする

参考: https://github.com/axios/axios/issues/10590

## Test plan
- [ ] `npm ls axios` で `1.9.0` が固定されていることを確認
- [ ] `node_modules/plain-crypto-js` が存在しないことを確認
- [ ] `npm run build` が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)