### PR TITLE
feat: Support WAROOM_BASE_URL environment variable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ dotenv.config();
 
 const waroomClient = new WaroomClient({
   apiKey: process.env.WAROOM_API_KEY || '',
+  ...(process.env.WAROOM_BASE_URL && { baseUrl: process.env.WAROOM_BASE_URL }),
 });
 
 const server = new McpServer({


### PR DESCRIPTION
## Summary

環境変数 `WAROOM_BASE_URL` が設定されている場合に、`WaroomClient` の `baseUrl` として使用できるようにした。
未設定の場合は従来どおりデフォルト値（`https://api.app.waroom.com/api/v0`）が使われる。

### やったこと

`src/main.ts` で `WaroomClient` を初期化する際に、`process.env.WAROOM_BASE_URL` が存在する場合のみ `baseUrl` オプションを渡すようにした。

- `src/main.ts` — `WaroomClient` 初期化時に `WAROOM_BASE_URL` 環境変数のサポートを追加
