### PR TITLE
feat: ランブックの取得・更新ツールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ node dist/main.js
   - `postmortems.ts`: ポストモーテム関連のツール（一覧取得、作成、テンプレート取得）
   - `services.ts`: サービス関連のツール（一覧取得、アーキテクチャコンテキスト取得）
   - `labels.ts`: ラベル管理のツール（サービスラベル一覧取得、作成、更新、削除、インシデントラベル付与）
+  - `runbooks.ts`: ランブック関連のツール（一覧取得、詳細取得、更新）
 
 ### 技術スタック
 
@@ -86,6 +87,9 @@ node dist/main.js
 - `waroom_update_service_label`: 特定のサービスのラベルを更新
 - `waroom_delete_service_label`: 特定のサービスのラベルを削除
 - `waroom_update_incident_labels`: インシデントにラベルを付与または更新
+- `waroom_get_runbooks`: ランブック一覧取得
+- `waroom_get_runbook`: namespace による個別ランブック詳細
+- `waroom_update_runbook`: ランブックの更新（内容・namespace の変更）
 
 ### API エンドポイント
 
@@ -107,6 +111,9 @@ node dist/main.js
 - `PATCH /services/{service_name}/labels/{uuid}`: サービスのラベル更新
 - `DELETE /services/{service_name}/labels/{uuid}`: サービスのラベル削除
 - `PATCH /incidents/{uuid}/labels`: インシデントのラベル付与/更新
+- `GET /runbooks`: ランブック一覧
+- `GET /runbooks/{namespace}`: ランブック詳細（namespace はスラッシュを含むパス）
+- `PATCH /runbooks/{namespace}`: ランブック更新
 
 ## Claude Desktop での設定
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ claude mcp add waroom-mcp --env WAROOM_API_KEY=your-api-key -- npx @topotal/waro
 - `waroom_update_service_label`: 特定のサービスのラベルを更新
 - `waroom_delete_service_label`: 特定のサービスのラベルを削除
 
+### ランブック関連
+- `waroom_get_runbooks`: ページネーション対応のランブック一覧
+- `waroom_get_runbook`: namespace による個別ランブック詳細
+- `waroom_update_runbook`: ランブックの更新（内容・namespace の変更）
+
 ## スラッシュコマンド（Claude Code）
 
 Claude Code では、以下のスラッシュコマンドを使用してインシデント対応を効率化できます。

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",
         "@types/node": "^22.15.18",
-        "axios": "1.9.0",
+        "axios": "1.13.5",
         "dotenv": "^16.5.0",
         "typescript": "^5.8.3",
         "zod": "^3.24.4"
@@ -63,6 +63,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1601,6 +1602,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
       "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.32.1",
         "@typescript-eslint/types": "8.32.1",
@@ -2056,6 +2058,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2154,15 +2157,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -2342,6 +2347,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2628,6 +2634,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2759,6 +2766,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2893,6 +2901,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -2935,6 +2944,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz",
       "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3183,6 +3193,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3373,15 +3384,16 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -3409,14 +3421,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3426,6 +3440,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3434,6 +3449,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3706,6 +3722,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -3717,9 +3734,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4022,6 +4040,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -6186,6 +6205,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6601,6 +6621,7 @@
       "version": "3.24.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/WaroomClient.ts
+++ b/src/WaroomClient.ts
@@ -206,6 +206,42 @@ export class WaroomClient {
     }
   }
 
+  async getRunbooks(page = 1, perPage = 50) {
+    try {
+      const response = await this.axiosInstance.get(`${this.baseUrl}/runbooks`, {
+        params: { page, per_page: perPage }
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to get runbooks: ${error}`);
+    }
+  }
+
+  async getRunbook(namespace: string) {
+    try {
+      const response = await this.axiosInstance.get(`${this.baseUrl}/runbooks/${this.encodeNamespacePath(namespace)}`);
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to get runbook: ${error}`);
+    }
+  }
+
+  async updateRunbook(namespace: string, updates: { namespace?: string; blob?: string }) {
+    try {
+      const response = await this.axiosInstance.patch(`${this.baseUrl}/runbooks/${this.encodeNamespacePath(namespace)}`, {
+        runbook: updates
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to update runbook: ${error}`);
+    }
+  }
+
+  // namespace はスラッシュを含むパスなので、セグメント単位でエンコードする
+  private encodeNamespacePath(namespace: string) {
+    return namespace.replace(/^\//, '').split('/').map(encodeURIComponent).join('/');
+  }
+
   async updateIncidentLabels(incidentUuid: string, labelUuids: string[]) {
     try {
       const response = await this.axiosInstance.patch(`${this.baseUrl}/incidents/${incidentUuid}/labels`, {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { createIncidentsTools } from './tools/incidents.js';
 import { createPostmortemsTools } from './tools/postmortems.js';
 import { createServicesTools } from './tools/services.js';
 import { createLabelsTools } from './tools/labels.js';
+import { createRunbooksTools } from './tools/runbooks.js';
 import { getIncidentResponsePromptMessages } from './prompts/incident-response.js';
 import { getIncidentRespondPromptMessages } from './prompts/incident-respond.js';
 import { aboutContent } from './resources/about.js';
@@ -28,6 +29,7 @@ createIncidentsTools(server, waroomClient);
 createPostmortemsTools(server, waroomClient);
 createServicesTools(server, waroomClient);
 createLabelsTools(server, waroomClient);
+createRunbooksTools(server, waroomClient);
 
 // リソースの登録
 server.resource(

--- a/src/tools/runbooks.ts
+++ b/src/tools/runbooks.ts
@@ -1,0 +1,101 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WaroomClient } from '../WaroomClient.js';
+import { z } from 'zod';
+
+export const createRunbooksTools = (server: McpServer, waroomClient: WaroomClient) => {
+  server.tool(
+    'waroom_get_runbooks',
+    'ランブックの一覧を取得します。',
+    {
+      page: z.number().int().min(1).optional().describe('取得するページ番号（1以上の整数）。デフォルト: 1'),
+      per_page: z.number().int().min(1).max(100).optional().describe('1ページあたりの取得数（1-100）。デフォルト: 50'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.getRunbooks(
+          params.page || 1,
+          params.per_page || 50
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `ランブック一覧の取得に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'waroom_get_runbook',
+    'ランブックの詳細を取得します。namespace で指定します。',
+    {
+      namespace: z.string().min(1).describe('ランブックの namespace（スラッシュを含むパス形式。例: /payments/db-failover）'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.getRunbook(params.namespace);
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `ランブックの取得に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'waroom_update_runbook',
+    'ランブックを更新します。namespace で対象を指定し、内容（blob）や namespace を変更できます。',
+    {
+      namespace: z.string().min(1).describe('更新対象のランブックの namespace（スラッシュを含むパス形式。例: /payments/db-failover）'),
+      blob: z.string().min(1).optional().describe('ランブックの新しい内容'),
+      new_namespace: z.string().min(1).optional().describe('変更後の namespace（namespace を変更する場合のみ指定）'),
+    },
+    async (params) => {
+      try {
+        if (!params.blob && !params.new_namespace) {
+          return {
+            content: [{
+              type: 'text',
+              text: 'blob または new_namespace のいずれかを指定してください。'
+            }]
+          };
+        }
+        const updates: { namespace?: string; blob?: string } = {};
+        if (params.blob) updates.blob = params.blob;
+        if (params.new_namespace) updates.namespace = params.new_namespace;
+
+        const response = await waroomClient.updateRunbook(params.namespace, updates);
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `ランブックの更新に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+};


### PR DESCRIPTION
## 概要

MCP 経由でランブックを取得・編集できるツールを追加します。waroom-backend の v0 API（`GET/PATCH /api/v0/runbooks`）を利用します。

## 追加ツール

- `waroom_get_runbooks`: ランブック一覧取得（page / per_page 対応）
- `waroom_get_runbook`: namespace 指定での詳細取得
- `waroom_update_runbook`: 内容（blob）・namespace の更新。両方未指定の場合はエラーメッセージを返す

## 実装メモ

- ランブックの識別子は UUID ではなく namespace（スラッシュを含むパス、BE 側は glob ルーティング）。セグメント単位で URL エンコードして API パスに埋め込む
- 作成・削除（POST / DELETE）は今回のスコープ外
- `package-lock.json` の差分は PR #19 の axios 1.13.5 アップグレードとの同期（別コミットに分離）

## 動作確認

- `npm run build`（tsc）成功
- `npm run lint` は eslint.config.js 不在のため既存から失敗する状態（本 PR とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nnr6aYjam8vJWzUnCn1SEQ