### PR TITLE
feat: サービスアーキテクチャコンテキストの更新ツールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ node dist/main.js
 - `waroom_get_postmortem_template`: ポストモーテムテンプレート取得
 - `waroom_get_services`: サービス一覧取得
 - `waroom_get_service_architecture_context`: 特定のサービスのアーキテクチャコンテキスト取得
+- `waroom_update_service_architecture_context`: 特定のサービスのアーキテクチャコンテキスト更新（既存があれば更新、無ければ新規作成）
 - `waroom_update_incident_severity`: インシデント重要度の更新
 - `waroom_update_incident_status`: インシデントステータスの更新
 - `waroom_create_incident_metrics`: インシデントメトリクスの作成（TTD/TTA/TTI/TTF/TTR更新）
@@ -103,6 +104,7 @@ node dist/main.js
 - `GET /postmortem_template`: ポストモーテムテンプレート取得
 - `GET /services`: サービス一覧
 - `GET /services/{name}/service_architecture_context`: 特定のサービスのアーキテクチャコンテキスト取得
+- `PATCH /services/{name}/service_architecture_context`: 特定のサービスのアーキテクチャコンテキスト更新
 - `PUT /incidents/{uuid}/severity`: インシデント重要度の更新
 - `PUT /incidents/{uuid}/status`: インシデントステータスの更新
 - `POST /incidents/{uuid}/metrics`: インシデントメトリクスの作成

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ claude mcp add waroom-mcp --env WAROOM_API_KEY=your-api-key -- npx @topotal/waro
 ### サービス関連
 - `waroom_get_services`: サービス一覧取得
 - `waroom_get_service_architecture_context`: 特定のサービスのアーキテクチャコンテキスト取得
+- `waroom_update_service_architecture_context`: 特定のサービスのアーキテクチャコンテキスト更新
 
 ### ラベル管理
 - `waroom_get_service_labels`: 特定のサービスのラベル一覧を取得

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@topotal/waroom-mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@topotal/waroom-mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topotal/waroom-mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Waroom MCP Server - Access Waroom API through Model Context Protocol",
   "publishConfig": {
     "access": "public"

--- a/src/WaroomClient.ts
+++ b/src/WaroomClient.ts
@@ -106,6 +106,19 @@ export class WaroomClient {
     }
   }
 
+  async updateServiceArchitectureContext(serviceName: string, blob: string) {
+    try {
+      const response = await this.axiosInstance.patch(`${this.baseUrl}/services/${serviceName}/service_architecture_context`, {
+        service_architecture_context: {
+          blob
+        }
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to update service architecture context: ${error}`);
+    }
+  }
+
   async createIncident(serviceNameorId: string, title: string, severity: string, description?: string, experimental?: boolean, isPrivate?: boolean) {
     try {
       const response = await this.axiosInstance.post(`${this.baseUrl}/incidents`, {

--- a/src/tools/services.ts
+++ b/src/tools/services.ts
@@ -58,4 +58,31 @@ export const createServicesTools = (server: McpServer, waroomClient: WaroomClien
       }
     }
   );
+
+  server.tool(
+    'waroom_update_service_architecture_context',
+    '特定のサービスのアーキテクチャコンテキストを更新します。既存のコンテキストがあれば更新し、無ければ新規作成されます。',
+    {
+      service_name: z.string().min(1).max(100).describe('サービス名'),
+      blob: z.string().min(1).describe('アーキテクチャコンテキストの内容'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.updateServiceArchitectureContext(params.service_name, params.blob);
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `サービスアーキテクチャコンテキストの更新に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
 };


### PR DESCRIPTION
## 概要

Closes #23

サービスコンテキスト（service architecture context）を **更新** する MCP ツール `waroom_update_service_architecture_context` を追加しました。これまで取得ツールのみで更新手段がなかったため、取得〜編集〜反映を一気通貫で行えるようになります。

## 変更内容

- `WaroomClient.updateServiceArchitectureContext(serviceName, blob)` を追加
  - `PATCH /api/v0/services/{service_name}/service_architecture_context` を呼び出す
  - リクエストボディ: `{ "service_architecture_context": { "blob": "..." } }`
  - 既存 context があれば更新、無ければ新規作成される
- `waroom_update_service_architecture_context` ツールを追加（`src/tools/services.ts`）
  - パラメータ: `service_name`, `blob`
  - エラー時は失敗メッセージを返却
- ドキュメント（CLAUDE.md / README.md）を更新

## 実装方針

既存の `waroom_get_service_architecture_context` や `waroom_update_runbook` 等の update 系ツールのパターンに倣いました。

## 確認

- [x] `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)