### PR TITLE
feat: アクションアイテム操作ツールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ node dist/main.js
   - `services.ts`: サービス関連のツール（一覧取得、アーキテクチャコンテキスト取得）
   - `labels.ts`: ラベル管理のツール（サービスラベル一覧取得、作成、更新、削除、インシデントラベル付与）
   - `runbooks.ts`: ランブック関連のツール（一覧取得、詳細取得、更新）
+  - `actionItems.ts`: アクションアイテム関連のツール（一覧取得、作成、詳細取得、更新、削除）
+  - `users.ts`: ユーザー関連のツール（一覧取得）
 
 ### 技術スタック
 
@@ -91,6 +93,12 @@ node dist/main.js
 - `waroom_get_runbooks`: ランブック一覧取得
 - `waroom_get_runbook`: namespace による個別ランブック詳細
 - `waroom_update_runbook`: ランブックの更新（内容・namespace の変更）
+- `waroom_get_incident_action_items`: 特定のインシデントのアクションアイテム一覧を取得
+- `waroom_create_incident_action_item`: 特定のインシデントにアクションアイテムを作成
+- `waroom_get_incident_action_item`: アクションアイテムの詳細取得
+- `waroom_update_incident_action_item`: アクションアイテムの更新（タイトル・ステータス・担当者）
+- `waroom_delete_incident_action_item`: アクションアイテムの削除
+- `waroom_get_users`: 組織のユーザー一覧を取得
 
 ### API エンドポイント
 
@@ -116,6 +124,12 @@ node dist/main.js
 - `GET /runbooks`: ランブック一覧
 - `GET /runbooks/{namespace}`: ランブック詳細（namespace はスラッシュを含むパス）
 - `PATCH /runbooks/{namespace}`: ランブック更新
+- `GET /incidents/{uuid}/action_items`: インシデントのアクションアイテム一覧
+- `POST /incidents/{uuid}/action_items`: インシデントのアクションアイテム作成
+- `GET /incidents/{uuid}/action_items/{action_item_uuid}`: アクションアイテム詳細
+- `PATCH /incidents/{uuid}/action_items/{action_item_uuid}`: アクションアイテム更新（title・status・assignee_nickname、null で解除）
+- `DELETE /incidents/{uuid}/action_items/{action_item_uuid}`: アクションアイテム削除
+- `GET /users`: 組織のユーザー一覧
 
 ## Claude Desktop での設定
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ claude mcp add waroom-mcp --env WAROOM_API_KEY=your-api-key -- npx @topotal/waro
 - `waroom_get_runbook`: namespace による個別ランブック詳細
 - `waroom_update_runbook`: ランブックの更新（内容・namespace の変更）
 
+### アクションアイテム関連
+- `waroom_get_incident_action_items`: 特定のインシデントのアクションアイテム一覧を取得
+- `waroom_create_incident_action_item`: 特定のインシデントにアクションアイテムを作成
+- `waroom_get_incident_action_item`: アクションアイテムの詳細取得
+- `waroom_update_incident_action_item`: アクションアイテムの更新（タイトル・ステータス・担当者）
+- `waroom_delete_incident_action_item`: アクションアイテムの削除
+
+### ユーザー関連
+- `waroom_get_users`: 組織のユーザー一覧を取得（担当者指定に使う nickname の確認）
+
 ## スラッシュコマンド（Claude Code）
 
 Claude Code では、以下のスラッシュコマンドを使用してインシデント対応を効率化できます。

--- a/src/WaroomClient.ts
+++ b/src/WaroomClient.ts
@@ -88,6 +88,17 @@ export class WaroomClient {
     }
   }
 
+  async getUsers(page = 1, perPage = 50) {
+    try {
+      const response = await this.axiosInstance.get(`${this.baseUrl}/users`, {
+        params: { page, per_page: perPage }
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to get users: ${error}`);
+    }
+  }
+
   async getPostmortemTemplate() {
     try {
       const response = await this.axiosInstance.get(`${this.baseUrl}/postmortem_template`);
@@ -253,6 +264,60 @@ export class WaroomClient {
   // namespace はスラッシュを含むパスなので、セグメント単位でエンコードする
   private encodeNamespacePath(namespace: string) {
     return namespace.replace(/^\//, '').split('/').map(encodeURIComponent).join('/');
+  }
+
+  async getIncidentActionItems(incidentUuid: string, page = 1, perPage = 50) {
+    try {
+      const response = await this.axiosInstance.get(`${this.baseUrl}/incidents/${incidentUuid}/action_items`, {
+        params: { page, per_page: perPage }
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to get incident action items: ${error}`);
+    }
+  }
+
+  async createIncidentActionItem(incidentUuid: string, title: string, status?: string) {
+    try {
+      const response = await this.axiosInstance.post(`${this.baseUrl}/incidents/${incidentUuid}/action_items`, {
+        action_item: {
+          title,
+          ...(status && { status })
+        }
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to create incident action item: ${error}`);
+    }
+  }
+
+  async updateIncidentActionItem(incidentUuid: string, actionItemUuid: string, updates: { title?: string; status?: string; assignee_nickname?: string | null }) {
+    try {
+      const response = await this.axiosInstance.patch(`${this.baseUrl}/incidents/${incidentUuid}/action_items/${actionItemUuid}`, {
+        action_item: updates
+      });
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to update incident action item: ${error}`);
+    }
+  }
+
+  async getIncidentActionItem(incidentUuid: string, actionItemUuid: string) {
+    try {
+      const response = await this.axiosInstance.get(`${this.baseUrl}/incidents/${incidentUuid}/action_items/${actionItemUuid}`);
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to get incident action item: ${error}`);
+    }
+  }
+
+  async deleteIncidentActionItem(incidentUuid: string, actionItemUuid: string) {
+    try {
+      const response = await this.axiosInstance.delete(`${this.baseUrl}/incidents/${incidentUuid}/action_items/${actionItemUuid}`);
+      return response.data;
+    } catch (error) {
+      throw new Error(`Failed to delete incident action item: ${error}`);
+    }
   }
 
   async updateIncidentLabels(incidentUuid: string, labelUuids: string[]) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,8 @@ import { createPostmortemsTools } from './tools/postmortems.js';
 import { createServicesTools } from './tools/services.js';
 import { createLabelsTools } from './tools/labels.js';
 import { createRunbooksTools } from './tools/runbooks.js';
+import { createActionItemsTools } from './tools/actionItems.js';
+import { createUsersTools } from './tools/users.js';
 import { getIncidentResponsePromptMessages } from './prompts/incident-response.js';
 import { getIncidentRespondPromptMessages } from './prompts/incident-respond.js';
 import { aboutContent } from './resources/about.js';
@@ -30,6 +32,8 @@ createPostmortemsTools(server, waroomClient);
 createServicesTools(server, waroomClient);
 createLabelsTools(server, waroomClient);
 createRunbooksTools(server, waroomClient);
+createActionItemsTools(server, waroomClient);
+createUsersTools(server, waroomClient);
 
 // リソースの登録
 server.resource(

--- a/src/tools/actionItems.ts
+++ b/src/tools/actionItems.ts
@@ -1,0 +1,177 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WaroomClient } from '../WaroomClient.js';
+import { z } from 'zod';
+
+export const createActionItemsTools = (server: McpServer, waroomClient: WaroomClient) => {
+  server.tool(
+    'waroom_get_incident_action_items',
+    '特定のインシデントのアクションアイテム一覧を取得します。',
+    {
+      incident_uuid: z.string().uuid().describe('インシデントのUUID'),
+      page: z.number().int().min(1).optional().describe('取得するページ番号（1以上の整数）。デフォルト: 1'),
+      per_page: z.number().int().min(1).max(100).optional().describe('1ページあたりの取得数（1-100）。デフォルト: 50'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.getIncidentActionItems(
+          params.incident_uuid,
+          params.page || 1,
+          params.per_page || 50
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `アクションアイテム一覧の取得に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'waroom_create_incident_action_item',
+    '特定のインシデントに新しいアクションアイテムを作成します。',
+    {
+      incident_uuid: z.string().uuid().describe('インシデントのUUID'),
+      title: z.string().min(1).describe('アクションアイテムのタイトル'),
+      status: z.enum(['open', 'closed', 'skipped']).optional().describe('アクションアイテムのステータス。デフォルト: open'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.createIncidentActionItem(
+          params.incident_uuid,
+          params.title,
+          params.status
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `アクションアイテムの作成に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'waroom_get_incident_action_item',
+    '特定のインシデントのアクションアイテム詳細を取得します。',
+    {
+      incident_uuid: z.string().uuid().describe('インシデントのUUID'),
+      action_item_uuid: z.string().uuid().describe('アクションアイテムのUUID'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.getIncidentActionItem(
+          params.incident_uuid,
+          params.action_item_uuid
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `アクションアイテムの取得に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'waroom_update_incident_action_item',
+    '特定のインシデントのアクションアイテムを更新します。タイトル・ステータス（完了・スキップ等）・担当者を変更できます。',
+    {
+      incident_uuid: z.string().uuid().describe('インシデントのUUID'),
+      action_item_uuid: z.string().uuid().describe('アクションアイテムのUUID'),
+      title: z.string().min(1).optional().describe('アクションアイテムの新しいタイトル'),
+      status: z.enum(['open', 'closed', 'skipped']).optional().describe('アクションアイテムの新しいステータス（open: 未対応, closed: 完了, skipped: スキップ）'),
+      assignee_nickname: z.string().min(1).nullable().optional().describe('担当者の nickname（waroom_get_users で取得可能）。null を指定するとアサインを解除'),
+    },
+    async (params) => {
+      try {
+        const updates: { title?: string; status?: string; assignee_nickname?: string | null } = {};
+        if (params.title !== undefined) updates.title = params.title;
+        if (params.status !== undefined) updates.status = params.status;
+        if (params.assignee_nickname !== undefined) updates.assignee_nickname = params.assignee_nickname;
+
+        if (Object.keys(updates).length === 0) {
+          return {
+            content: [{
+              type: 'text',
+              text: 'title、status、assignee_nickname のいずれかを指定してください。'
+            }]
+          };
+        }
+
+        const response = await waroomClient.updateIncidentActionItem(
+          params.incident_uuid,
+          params.action_item_uuid,
+          updates
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `アクションアイテムの更新に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'waroom_delete_incident_action_item',
+    '特定のインシデントのアクションアイテムを削除します。',
+    {
+      incident_uuid: z.string().uuid().describe('インシデントのUUID'),
+      action_item_uuid: z.string().uuid().describe('アクションアイテムのUUID'),
+    },
+    async (params) => {
+      try {
+        await waroomClient.deleteIncidentActionItem(
+          params.incident_uuid,
+          params.action_item_uuid
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: 'アクションアイテムを削除しました。'
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `アクションアイテムの削除に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+};

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -1,0 +1,35 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WaroomClient } from '../WaroomClient.js';
+import { z } from 'zod';
+
+export const createUsersTools = (server: McpServer, waroomClient: WaroomClient) => {
+  server.tool(
+    'waroom_get_users',
+    '組織のユーザー一覧を取得します。アクションアイテムの担当者指定などに使う nickname を確認できます。',
+    {
+      page: z.number().int().min(1).optional().describe('取得するページ番号（1以上の整数）。デフォルト: 1'),
+      per_page: z.number().int().min(1).max(100).optional().describe('1ページあたりの取得数（1-100）。デフォルト: 50'),
+    },
+    async (params) => {
+      try {
+        const response = await waroomClient.getUsers(
+          params.page || 1,
+          params.per_page || 50
+        );
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(response, null, 2)
+          }]
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text',
+            text: `ユーザー一覧の取得に失敗しました: ${error}`
+          }]
+        };
+      }
+    }
+  );
+};


### PR DESCRIPTION
## 概要

Waroom v0 API のアクションアイテムエンドポイントに対応するツールを追加する。

topotal/waroom-backend#3292 で追加された PATCH エンドポイント（更新・アサイン）にも対応。

## 追加ツール

| ツール | エンドポイント |
|---|---|
| `waroom_get_incident_action_items` | `GET /incidents/{uuid}/action_items` |
| `waroom_create_incident_action_item` | `POST /incidents/{uuid}/action_items` |
| `waroom_get_incident_action_item` | `GET /incidents/{uuid}/action_items/{action_item_uuid}` |
| `waroom_update_incident_action_item` | `PATCH /incidents/{uuid}/action_items/{action_item_uuid}` |
| `waroom_delete_incident_action_item` | `DELETE /incidents/{uuid}/action_items/{action_item_uuid}` |
| `waroom_get_users` | `GET /users` |

- 更新ツールは title / status（open・closed・skipped）/ assignee_nickname を部分更新。`assignee_nickname: null` でアサイン解除、キー未指定なら変更なし
- `waroom_get_users` は担当者指定に使う nickname の確認用

## 検証

- `npm run build`: 成功
- MCP `tools/list` のスモークテストで全26ツール（新規6ツール含む）の登録を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YSPkxPq5Am1k4VshB3wed