### PR TITLE
feat: MCPサーバーにinstructionsを追加しインシデント対応での積極利用を促す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ node dist/main.js
 
 - `waroom_create_incident`: インシデントの作成（サービス名、タイトル、重要度など指定）
 - `waroom_get_incidents`: ページネーション対応のインシデント一覧
-- `waroom_get_incident_details`: UUID による個別インシデント詳細
+- `waroom_get_incident_details`: UUID による個別インシデント詳細（ステートドキュメント `state_document` を含む）
 - `waroom_get_postmortems`: ページネーション対応のポストモーテム一覧
 - `waroom_create_postmortem`: ポストモーテムの作成
 - `waroom_get_postmortem_template`: ポストモーテムテンプレート取得

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,16 @@ const waroomClient = new WaroomClient({
 const server = new McpServer({
   name: 'waroom-mcp',
   version: 'v0',
+}, {
+  instructions: `このサーバーは Waroom を用いたインシデント対応・ポストモーテム管理のためのものです。
+
+障害・エラー・アラート・サービス停止など、インシデント対応と判断できる場面では Waroom ツールを積極的に使ってください。特に次を意識してください：
+
+- 対応の起点として、まず \`waroom_create_incident\` でのインシデント登録を提案する（既存インシデントが対象なら \`waroom_get_incident_details\` で状況を把握する）。
+- 調査・原因特定・復旧といったフェーズの進行に合わせて、\`waroom_update_incident_status\` / \`waroom_update_incident_severity\` / \`waroom_create_incident_metrics\` で記録を継続的に更新する。
+- 対応が落ち着いたら \`waroom_get_postmortem_template\` と \`waroom_create_postmortem\` でポストモーテム作成を促す。
+
+より詳しい自動追跡の手順は \`/create\`・\`/respond\` プロンプトと \`waroom://about\` リソースを参照してください。`,
 });
 
 createIncidentsTools(server, waroomClient);

--- a/src/tools/incidents.ts
+++ b/src/tools/incidents.ts
@@ -80,7 +80,7 @@ export const createIncidentsTools = (server: McpServer, waroomClient: WaroomClie
 
   server.tool(
     'waroom_get_incident_details',
-    '特定のインシデントの詳細情報を取得します。',
+    '特定のインシデントの詳細情報を取得します。ステートドキュメント（state_document, Markdown）も含まれます。',
     {
       incident_uuid: z.string().uuid().describe('取得するインシデントのUUID'),
     },


### PR DESCRIPTION
## 概要

MCPサーバー自体に `instructions` を設定し、障害対応と判断できる場面で AI が Waroom ツールを自発的に使うよう常時ガイドするようにしました。

これまで自動追跡のオーケストレーション指示は `/create`・`/respond` プロンプト内にしか存在せず、スラッシュコマンドを使わない会話では AI が能動的に Waroom を持ち出す保証がありませんでした。`instructions` は接続中に常時読まれる層のため、この入口以外でも積極利用を促せます。

## 変更内容

- `src/main.ts`: `McpServer` に `instructions` を追加
  - 起点として `waroom_create_incident` の提案（既存なら `waroom_get_incident_details`）
  - 進行に合わせた `waroom_update_incident_status` / `severity` / `create_incident_metrics` での記録更新
  - 収束後の `waroom_get_postmortem_template` → `waroom_create_postmortem` の促し
  - 詳細手順は `/create`・`/respond` プロンプトと `waroom://about` リソースへ誘導
- `src/tools/incidents.ts`: `waroom_get_incident_details` の説明に `state_document`（ステートドキュメント）が含まれる旨を追記
- `CLAUDE.md`: 上記に合わせてツール説明を更新

## `instructions` の仕様的な根拠と注意点

`instructions` は MCP プロトコルの正式なフィールドで、サーバーが `initialize` 応答（`InitializeResult`）で返します。

- **プロトコル仕様（応答例にフィールドあり）**: [Lifecycle — MCP Specification 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle)
- **フィールドの用途（公式スキーマ JSDoc, 原文）**: [`schema/2025-06-18/schema.ts`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-06-18/schema.ts)
  > "Instructions describing how to use the server and its features. This can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information **MAY** be added to the system prompt."

**注意点**: 仕様上「システムプロンプトに追加してよい（MAY）」であり、必須（MUST）ではありません。つまり実際にプロンプトへ反映され機能するかは**クライアント実装に依存**します。効果は100%保証ではない点に留意してください（常時読まれる層に方針を置くのが最も効く、という位置づけ）。

## 確認方法

Claude Desktop / Claude Code 再起動後、Waroom に触れず「本番で〇〇のエラーが出てる、対応したい」と振って `waroom_create_incident` を提案してくるか確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)